### PR TITLE
Rely solely on `include` for binaries in matrix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,8 +58,6 @@ jobs:
     name: Upload executable binaries
     strategy:
       matrix:
-        os: [macos, ubuntu]
-        arch: [arm64, x86]
         include:
           - os: macos
             arch: arm64


### PR DESCRIPTION
**Context:**

**Changes In This Pull Request:**

**Test Plan:**
