### PR TITLE
fix(cli): escape pr submit edit bodies

### DIFF
--- a/apps/cli/src/actions/submit/submit_action.ts
+++ b/apps/cli/src/actions/submit/submit_action.ts
@@ -11,7 +11,7 @@ import {
   footerFooter,
   footerTitle,
 } from '../create_pr_body_footer';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 // eslint-disable-next-line max-lines-per-function
 export async function submitAction(
@@ -159,13 +159,13 @@ export async function submitAction(
     const prFooterChanged = !prInfo.body?.includes(footer);
 
     if (prFooterChanged) {
-      execSync(
-        `gh pr edit ${prInfo.number} --body '${updatePrBodyFooter(
-          prInfo.body,
-          footer
-        )}'
-      `
-      );
+      execFileSync('gh', [
+        'pr',
+        'edit',
+        `${prInfo.number}`,
+        '--body',
+        updatePrBodyFooter(prInfo.body, footer),
+      ]);
 
       context.splog.info(
         `${chalk.green(branch)}: ${prInfo.url} (${


### PR DESCRIPTION
**Context:**

On PR submit, I was getting errors like
~~~
🌳 Updating dependency trees in PR bodies...
accepts at most 1 arg(s), received 9
/bin/sh: line 2: This: command not found
/bin/sh: -c: line 3: unexpected EOF while looking for matching `''
/bin/sh: -c: line 5: syntax error: unexpected end of file
ERROR: Command failed: gh pr edit 561 --body '...stuff with a 'quote'...
~~~

**Changes In This Pull Request:**

Swapped the pr edit call to `gh` from `execSync` to `execFileSync`. This skips calling a shell and lets us pass args as an array where they'll get escaped automatically.

I believe this may address #86 - but I see other calls that might need to be updated as well. This particular one just happened to be bugging me though.

**Test Plan:**

I probably should add a test case to prevent regression, but I'm not entirely familiar with the  harness being used here or how to configure context for the pr.