### PR TITLE
Render PR dependency tree as a flat list for linear stacks

### DIFF
--- a/apps/cli/src/actions/create_pr_body_footer.ts
+++ b/apps/cli/src/actions/create_pr_body_footer.ts
@@ -9,65 +9,62 @@ export function createPrBodyFooter(context: TContext, branch: string): string {
 
   const tree = buildBranchTree({
     context,
-    currentBranches: [terminalParent],
+    branch: terminalParent,
     prBranch: branch,
-    currentDepth: 0,
+    depth: 0,
+    isForkHead: false,
   });
 
   return `${footerTitle}${tree}${footerFooter}`;
 }
 
+/**
+ * Renders the stack as a markdown list. A stack is linear, so a plain stack is
+ * a flat list. Indentation only encodes a genuine fork (a branch with 2+
+ * children on the PR's line): each child of the fork is indented one level as a
+ * sub-branch head, and that head's own linear sub-stack is indented one level
+ * deeper (and kept flat), so the sub-branches remain visually distinct.
+ */
 function buildBranchTree({
   context,
-  currentBranches,
+  branch,
   prBranch,
-  currentDepth,
+  depth,
+  isForkHead,
 }: {
   context: TContext;
-  currentBranches: string[];
+  branch: string;
   prBranch: string;
-  currentDepth: number;
+  depth: number;
+  isForkHead: boolean;
 }): string {
-  let tree = '';
+  const leaf = buildLeaf({ context, branch, depth, prBranch });
 
-  for (const branch of currentBranches) {
-    if (
-      branch !== prBranch &&
-      !(
-        // If we aren't on the last branch,
-        // then we should print it if the pr branch is either a parent or child
-        // of the current branch being looked at in our recursive algorithm
-        (
-          isParentOfBranch(context, branch, prBranch) ||
-          isParentOfBranch(context, prBranch, branch)
-        )
-      )
-    ) {
-      continue;
-    }
+  const children = context.engine
+    .getChildren(branch)
+    .filter((child) => isOnPrLine(context, child, prBranch));
 
-    const leaf = buildLeaf({
-      context,
-      branch,
-      depth: currentDepth,
-      prBranch,
-    });
-
-    tree += leaf || '';
-
-    const children = context.engine.getChildren(branch);
-
-    if (children.length) {
-      tree += `${buildBranchTree({
-        context,
-        currentBranches: children,
-        prBranch,
-        currentDepth: currentDepth + 1,
-      })}`;
-    }
+  if (children.length === 0) {
+    return leaf;
   }
 
-  return tree;
+  // A fork opens a nested level for its sub-branch heads; a linear step keeps
+  // the current level, except the first step off a fork head, which indents the
+  // head's sub-stack once so it reads as belonging to that head.
+  const isFork = children.length > 1;
+  const childDepth = isFork || isForkHead ? depth + 1 : depth;
+
+  const childTrees = children.map((child) =>
+    buildBranchTree({
+      context,
+      branch: child,
+      prBranch,
+      depth: childDepth,
+      isForkHead: isFork,
+    })
+  );
+
+  return `${leaf}${childTrees.join('')}`;
 }
 
 function buildLeaf({
@@ -80,13 +77,11 @@ function buildLeaf({
   branch: string;
   depth: number;
   prBranch: string;
-}): string | undefined {
-  const prInfo = context.engine.getPrInfo(branch);
-
-  const number = prInfo?.number;
+}): string {
+  const number = context.engine.getPrInfo(branch)?.number;
 
   if (!number) {
-    return;
+    return '';
   }
 
   return `\n${'  '.repeat(depth)}* **PR #${number}**${
@@ -105,6 +100,19 @@ function findTerminalParent(context: TContext, currentBranch: string): string {
   }
 
   return findTerminalParent(context, parent);
+}
+
+/** True if `branch` is the PR branch, or an ancestor or descendant of it. */
+function isOnPrLine(
+  context: TContext,
+  branch: string,
+  prBranch: string
+): boolean {
+  return (
+    branch === prBranch ||
+    isParentOfBranch(context, branch, prBranch) ||
+    isParentOfBranch(context, prBranch, branch)
+  );
 }
 
 function isParentOfBranch(

--- a/apps/cli/test/actions/create_pr_body_footer.test.ts
+++ b/apps/cli/test/actions/create_pr_body_footer.test.ts
@@ -1,0 +1,127 @@
+import { expect } from 'chai';
+import { TContext } from '../../src/lib/context';
+import {
+  createPrBodyFooter,
+  footerFooter,
+  footerTitle,
+} from '../../src/actions/create_pr_body_footer';
+
+const TRUNK = 'main';
+
+/**
+ * Builds a minimal fake context whose engine answers the four methods the
+ * footer relies on, derived from a branch -> parent map. Every non-trunk
+ * branch gets a PR number equal to its position in `parents` insertion order
+ * plus 100, unless overridden.
+ */
+function fakeContext(parents: Record<string, string>): TContext {
+  const branches = Object.keys(parents);
+  const prNumber = (branch: string) => 100 + branches.indexOf(branch);
+
+  const engine = {
+    isTrunk: (branch: string) => branch === TRUNK,
+    getParent: (branch: string) => parents[branch],
+    getChildren: (branch: string) =>
+      branches.filter((b) => parents[b] === branch),
+    getPrInfo: (branch: string) =>
+      branch === TRUNK ? undefined : { number: prNumber(branch) },
+  };
+
+  return { engine } as unknown as TContext;
+}
+
+/** Extracts the tree body between the footer's title and trailing signature. */
+function treeOf(footer: string): string {
+  return footer
+    .slice(footerTitle.length, footer.length - footerFooter.length)
+    .replace(/^\n/, '');
+}
+
+describe('createPrBodyFooter', () => {
+  it('renders a linear stack as a flat list', () => {
+    // main -> a -> b -> c, PR on b
+    const context = fakeContext({ a: TRUNK, b: 'a', c: 'b' });
+
+    const tree = treeOf(createPrBodyFooter(context, 'b'));
+
+    expect(tree).to.equal(
+      ['* **PR #100**', '* **PR #101** 👈', '* **PR #102**'].join('\n')
+    );
+  });
+
+  it('does not indent a single-child descendant', () => {
+    // main -> a -> b, PR on a
+    const context = fakeContext({ a: TRUNK, b: 'a' });
+
+    const tree = treeOf(createPrBodyFooter(context, 'a'));
+
+    expect(tree).to.equal(['* **PR #100** 👈', '* **PR #101**'].join('\n'));
+  });
+
+  it('indents each sub-branch at a genuine fork', () => {
+    // main -> x, x -> y -> z, x -> m -> n, PR on x
+    const context = fakeContext({
+      x: TRUNK,
+      y: 'x',
+      z: 'y',
+      m: 'x',
+      n: 'm',
+    });
+
+    const tree = treeOf(createPrBodyFooter(context, 'x'));
+
+    expect(tree).to.equal(
+      [
+        '* **PR #100** 👈',
+        '  * **PR #101**',
+        '    * **PR #102**',
+        '  * **PR #103**',
+        '    * **PR #104**',
+      ].join('\n')
+    );
+  });
+
+  it('keeps a linear sub-stack below a fork flat (no staircase within a branch)', () => {
+    // main -> x, x -> y -> z -> z2, x -> m, PR on x
+    const context = fakeContext({
+      x: TRUNK,
+      y: 'x',
+      z: 'y',
+      z2: 'z',
+      m: 'x',
+    });
+
+    const tree = treeOf(createPrBodyFooter(context, 'x'));
+
+    expect(tree).to.equal(
+      [
+        '* **PR #100** 👈',
+        '  * **PR #101**',
+        '    * **PR #102**',
+        '    * **PR #103**',
+        '  * **PR #104**',
+      ].join('\n')
+    );
+  });
+
+  it('flattens the ancestor spine, indenting only at a downstream fork', () => {
+    // main -> a -> b, b -> c, b -> d, PR on a
+    const context = fakeContext({
+      a: TRUNK,
+      b: 'a',
+      c: 'b',
+      d: 'b',
+    });
+
+    const tree = treeOf(createPrBodyFooter(context, 'a'));
+
+    expect(tree).to.equal(
+      [
+        '* **PR #100** 👈',
+        '* **PR #101**',
+        '  * **PR #102**',
+        '  * **PR #103**',
+      ].join('\n')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #140.

The auto-generated **PR Dependency Tree** section indented each branch one level deeper than the last. Since a stack is a linear sequence, that staircase conveyed no information and only got harder to read as the stack grew.

This flattens linear runs. Indentation now encodes **only a genuine fork** — a branch with 2+ children on the PR's line. At a fork, each child is indented one level as a sub-branch head, and that head's own linear sub-stack is indented one level deeper (and kept flat), so sibling sub-branches stay visually distinct.

## Before / after

**Linear stack `A → B → C`** (PR on `B`):

Before:
```
* **PR #100**
  * **PR #101** 👈
    * **PR #102**
```
After:
```
* **PR #100**
* **PR #101** 👈
* **PR #102**
```

**Genuine fork** — PR `#X` with sub-stacks `Y → Z` and `M → N` (indentation preserved, since it reflects real branching):
```
* **PR #X** 👈
  * **PR #Y**
    * **PR #Z**
  * **PR #M**
    * **PR #N**
```

## Tests

Adds `apps/cli/test/actions/create_pr_body_footer.test.ts` covering:
- linear stack → flat list
- single-child descendant → not indented
- genuine fork → sub-branches indented
- linear sub-stack below a fork → flat within the branch (no staircase)
- ancestor spine flat, indenting only at a downstream fork

Full suite (229 tests), lint, and typecheck all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)